### PR TITLE
Flush Cache After Scenario

### DIFF
--- a/src/Context/DatabaseTransactions.php
+++ b/src/Context/DatabaseTransactions.php
@@ -2,7 +2,7 @@
 
 namespace Laracasts\Behat\Context;
 
-use DB;
+use DB, Cache;
 
 trait DatabaseTransactions
 {
@@ -26,6 +26,7 @@ trait DatabaseTransactions
     public static function rollback()
     {
         DB::rollback();
+        Cache::flush();
     }
 
 }


### PR DESCRIPTION
When using ScenarioOutline the Cache still persists even though setting the driver to be array. Adding Cache flush resolves this issue.
