### PR TITLE
Remove 'future' parameters on emptyInbox

### DIFF
--- a/src/Context/Services/MailTrap.php
+++ b/src/Context/Services/MailTrap.php
@@ -73,7 +73,7 @@ trait MailTrap
      */
     public function emptyInbox()
     {
-        $this->requestClient()->patch($this->getMailTrapCleanUrl(), ['future' => true]);
+        $this->requestClient()->patch($this->getMailTrapCleanUrl());
     }
 
     /**


### PR DESCRIPTION
`emptyInbox` method for Mailtrap was throwing `InvalidArgumentException` when `@mail` tag was fired after scenario

> No method is configured to handle the future config key (InvalidArgumentException)

With removal this will still clean inbox without errors
