### PR TITLE
@AfterScenario and @mail on one line prevented inbox to be emptied

### DIFF
--- a/src/Context/Services/MailTrap.php
+++ b/src/Context/Services/MailTrap.php
@@ -69,7 +69,8 @@ trait MailTrap
      *
      * Empty the MailTrap inbox.
      *
-     * @AfterScenario @mail
+     * @AfterScenario 
+     * @mail
      */
     public function emptyInbox()
     {


### PR DESCRIPTION
I found out that even though I used the trait and all other stuff worked, it never emptied my inbox.
For me, placing `@mail` on a new line fixed the problem
