### PR TITLE
Runs migrate:refresh as an afterScenario to reset the primary keys

### DIFF
--- a/src/Context/Migrator.php
+++ b/src/Context/Migrator.php
@@ -17,4 +17,14 @@ trait Migrator
         Artisan::call('migrate');
     }
 
+    /**
+     * Refresh the database after each scenario.
+     *
+     * @afterScenario
+     */
+    public function refresh()
+    {
+        Artisan::call('migrate:refresh');
+    }
+
 }


### PR DESCRIPTION
Every created record in a MySql database increments the primary key by one.  Creating one record per test means that after 50 tests, the primary key will be 51.  'php artisan migrate:refresh'  ensures that the primary keys will be the same for each test.
