### PR TITLE
Proposal: Make another trait to refresh the database

### DIFF
--- a/src/Context/MigratorRefresh
+++ b/src/Context/MigratorRefresh
@@ -1,0 +1,15 @@
+<?php
+namespace Laracasts\Behat\Context;
+use Artisan;
+trait MigratorRefresh
+{
+    /**
+     * Migrate and refresh the database before each scenario.
+     *
+     * @beforeScenario
+     */
+    public function migrateAndRefresh()
+    {
+        Artisan::call('migrate:refresh');
+    }
+}


### PR DESCRIPTION
Before each run of the Scenario this can help basically reset the database.

So on the first run it will start fresh and from there on, for each Scenario be fresh again.

Maybe the transactions trait are enough for this especially when used with the migrator trait but over all this has been helpful for me.
