### PR TITLE
Added base_uri to support Guzzle 6

### DIFF
--- a/src/Context/Services/MailTrap.php
+++ b/src/Context/Services/MailTrap.php
@@ -115,7 +115,10 @@ trait MailTrap
     {
         if ( ! $this->client) {
             $this->client = new Client([
+                // Guzzle 5.* uses base_url
                 'base_url' => 'https://mailtrap.io',
+                // Guzzle 6.* uses base_uri
+                'base_uri' => 'https://mailtrap.ip',
                 'defaults' => [
                     'headers' => ['Api-Token' => $this->mailTrapApiKey]
                 ]


### PR DESCRIPTION
See changes in: https://github.com/guzzle/guzzle/blob/master/UPGRADING.md#post-requests

By adding `base_uri` to the array the library supports both Guzzle 5 and Guzzle 6.
