### PR TITLE
Fix switching between js/non-js supported drivers

### DIFF
--- a/src/Context/KernelAwareInitializer.php
+++ b/src/Context/KernelAwareInitializer.php
@@ -5,6 +5,7 @@ namespace Laracasts\Behat\Context;
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\Initializer\ContextInitializer;
 use Behat\Behat\EventDispatcher\Event\ScenarioTested;
+use Laracasts\Behat\Driver\KernelDriver;
 use Laracasts\Behat\ServiceContainer\LaravelBooter;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -71,13 +72,15 @@ class KernelAwareInitializer implements EventSubscriberInterface, ContextInitial
      */
     public function rebootKernel()
     {
-        $this->kernel->flush();
+        $driver = $this->context->getSession('laravel')->getDriver();
 
-        $laravel = new LaravelBooter($this->kernel->basePath(), $this->kernel->environmentFile());
+        if ($driver instanceof KernelDriver) {
+            $this->kernel->flush();
 
-        $this->context->getSession('laravel')->getDriver()->reboot($this->kernel = $laravel->boot());
-
-        $this->setAppOnContext();
+            $laravel = new LaravelBooter($this->kernel->basePath(), $this->kernel->environmentFile());
+            $driver->reboot($this->kernel = $laravel->boot());
+            $this->setAppOnContext();
+        }
     }
 
 }


### PR DESCRIPTION
I've found an issue in the extension when using the Selenium 2 driver for Javascript tests along side the Laravel extension for non javascript tests. This breaks because it will call the reboot method on the wrong driver type after the tests using the Selenium 2 driver have run.

An example snippet of the MinkExtension configuration is below.

``` yaml
    Behat\MinkExtension:
        default_session: laravel
        base_url: http://localhost:8000
        laravel: ~
        selenium2:
          wd_host: "http://localhost:8643/wd/hub"
```
