### PR TITLE
Execute hook only after scenario's that are tagged with "mail"

### DIFF
--- a/src/Context/Services/MailTrap.php
+++ b/src/Context/Services/MailTrap.php
@@ -72,8 +72,7 @@ trait MailTrap
      *
      * Empty the MailTrap inbox.
      *
-     * @AfterScenario 
-     * @mail
+     * @AfterScenario @mail
      */
     public function emptyInbox()
     {


### PR DESCRIPTION
Right now the hook that empties the inbox is executed after every scenario in stead of the ones that are tagged with the @mail tag.
This fix will make sure the afterScenario hook will only get called after scenario's that actually have that tag.