### PR TITLE
Added functionality to transact more than one DB

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
-    "name": "troccoli/behat-laravel-extension",
+    "name": "laracasts/behat-laravel-extension",
     "type": "behat-extension",
     "description": "Laravel extension for Behat",
     "keywords": ["laravel", "behat", "extension", "bdd"],
     "license": "MIT",
     "authors": [
         {
-            "name": "Giulio Troccoli-Allard",
-            "email": "giulio@troccoli.it"
+            "name": "JeffreyWay",
+            "email": "jeffrey@laracasts.com"
         }
     ],
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -1,13 +1,13 @@
 {
-    "name": "laracasts/behat-laravel-extension",
+    "name": "troccoli/behat-laravel-extension",
     "type": "behat-extension",
     "description": "Laravel extension for Behat",
     "keywords": ["laravel", "behat", "extension", "bdd"],
     "license": "MIT",
     "authors": [
         {
-            "name": "JeffreyWay",
-            "email": "jeffrey@laracasts.com"
+            "name": "Giulio Troccoli-Allard",
+            "email": "giulio@troccoli.it"
         }
     ],
     "autoload": {

--- a/src/Context/DatabaseTransactions.php
+++ b/src/Context/DatabaseTransactions.php
@@ -39,10 +39,7 @@ trait DatabaseTransactions
     public function rollback()
     {
         foreach ($this->connectionsToTransact() as $name) {
-            $connection = DB::connection($name);
-
-            $connection->rollBack();
-            $connection->disconnect();
+            DB::connection($name)->rollBack();
         }
         Cache::flush();
     }


### PR DESCRIPTION
Inspired by Laravel DatabaseTransaction trait this change allow a user to rollback transactions on more than one database, by defining the connectionsToTransact array in their own Context class.