### PR TITLE
Updated readme to include symfony/dependency-injection as a dependency

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ To get started, you only need to follow a few steps:
 
 As always, we need to pull in some dependencies through Composer.
 
-    composer require behat/behat behat/mink behat/mink-extension laracasts/behat-laravel-extension --dev
+    composer require behat/behat behat/mink behat/mink-extension laracasts/behat-laravel-extension symfony/dependency-injection:"3.*" --dev
 
 This will give us access to Behat, Mink, and, of course, the Laravel extension.
 


### PR DESCRIPTION
Should close #72 and referenced on a Behat issue (https://github.com/Behat/Behat/issues/1108).

This seems to be a Behat issue, but helps to avoid confusion as I ran into this myself.