### PR TITLE
Fix for #78 (also linked to #80): Update to be compatible with Laravel 5.6

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -14,7 +14,7 @@ To get started, you only need to follow a few steps:
 
 As always, we need to pull in some dependencies through Composer.
 
-    composer require behat/behat behat/mink behat/mink-extension laracasts/behat-laravel-extension symfony/dependency-injection:"3.*" --dev
+    composer require behat/behat behat/mink behat/mink-extension laracasts/behat-laravel-extension --dev
 
 This will give us access to Behat, Mink, and, of course, the Laravel extension.
 

--- a/src/ServiceContainer/BehatExtension.php
+++ b/src/ServiceContainer/BehatExtension.php
@@ -5,6 +5,7 @@ namespace Laracasts\Behat\ServiceContainer;
 use Behat\Testwork\ServiceContainer\Extension;
 use Behat\Testwork\ServiceContainer\ExtensionManager;
 use Symfony\Component\DependencyInjection\Definition;
+use Symfony\Component\DependencyInjection\Reference;
 use Behat\Behat\Context\ServiceContainer\ContextExtension;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Laracasts\Behat\Context\Argument\LaravelArgumentResolver;
@@ -105,7 +106,9 @@ class BehatExtension implements Extension
      */
     private function loadLaravelArgumentResolver(ContainerBuilder $container, $app)
     {
-        $definition = new Definition(LaravelArgumentResolver::class, [$app]);
+        $definition = new Definition(LaravelArgumentResolver::class, [
+            new Reference('laravel.app')
+        ]);
         $definition->addTag(ContextExtension::ARGUMENT_RESOLVER_TAG, ['priority' => 0]);
         $container->setDefinition('laravel.context.argument.service_resolver', $definition);
     }


### PR DESCRIPTION
When used with Behat/Behat@826f32 (now merged into Behat/Behat@master), this allows all relevant references to be serialized by Symfony DI.

Symfony 4.x replaces `json_encode` with `serialize`, which throws an exception, instead of failing silently, when it comes across closures. This removes a closure in Behat-Laravel-Extension, specifically by replacing the app object with a reference to it. The Behat commit above removes another, and so the DI serialization can complete successfully.

The recent Behat commit is a soft dependency - both are required for L5.6 to work, but this commit is otherwise independent of it and should not break BC (as it swaps `$app` for a reference already inserted to DI by Behat-Laravel-Extension).