### PR TITLE
Reboot Kernel before scenario instead of after

### DIFF
--- a/src/Context/KernelAwareInitializer.php
+++ b/src/Context/KernelAwareInitializer.php
@@ -5,6 +5,7 @@ namespace Laracasts\Behat\Context;
 use Behat\Behat\Context\Context;
 use Behat\Behat\Context\Initializer\ContextInitializer;
 use Behat\Behat\EventDispatcher\Event\ScenarioTested;
+use Behat\Testwork\EventDispatcher\Event\SuiteTested;
 use Laracasts\Behat\ServiceContainer\LaravelBooter;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\HttpKernel\HttpKernelInterface;
@@ -42,7 +43,8 @@ class KernelAwareInitializer implements EventSubscriberInterface, ContextInitial
     public static function getSubscribedEvents()
     {
         return [
-            ScenarioTested::AFTER => ['rebootKernel', -15]
+            SuiteTested::BEFORE => ['rebootKernel', 15],
+            ScenarioTested::BEFORE => ['rebootKernel', 15]
         ];
     }
 


### PR DESCRIPTION
Rebooting the kernel after a scenario instead of before makes running tests inconsistent. This is because anything that is done during suite setup (`@BeforeSuite`) can taint the kernel and carry over into the first scenario, but won't be present for the second scenario and onwards because those will have had their kernels rebooted. To make sure that `@BeforeSuite` also uses a clean kernel and is not tainted by the last scenario if you are running multiple suites, the kernel should also be rebooted before every suite.

Take for example singletons. Let's say in our service provider we have the following:

```
$this->app->bind(MyInterface::class, MyConcrete::class);
$this->app->singleton(MyService::class, function() { return new MyService($this->app->make(MyInterface::class)); }); // the anonymous function here is redundant of course, it's just to show that we need a MyInterface when creating a MyService
```

Now in an `@BeforeSuite` we do:

```
App::make(MyService::class)->bootstrap();
```

This will create a `MyService` with a `MyConcrete`.

An in an `@BeforeScenario` we do:

```
$this->app->bind(MyInterface::class, MyConcreteTest::class);
```

Now when we run the test, and at some point it runs into a `$this->app->make(MyService::class)` it is supposed to create a `MyService` with a `MyConcreteTest`. But if it is the first test in the suite, we get returned the `MyService` with the `MyConcrete` because it's a singleton and rebinding `MyInterface` will not recreate `MyService`. So if the scenario is run as the first test in the suite we get a `MyService` with a `MyConcrete`, but if it's run as the second or later test we get a `MyService` with a `MyConcreteTest`.

Now if we only subscribe to `ScenarioTested::BEFORE` we solve this problem, but we also create a problem if you're running more than one suite. Then suddenly the `@BeforeSuite` will get a `MyService` with a `MyConcreteTest` if that scenario was the last in the previous suite to run, so we want to make sure we also reboot the kernel before a suite so we can start with a clean kernel in our next suite as well. Here we reboot again before the suite rather than after to make sure we don't have a difference between the first and subsequent suites.